### PR TITLE
Fix setup_vcpkg.sh argument forwarding

### DIFF
--- a/setup_vcpkg.sh
+++ b/setup_vcpkg.sh
@@ -76,4 +76,4 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # --- 執行主函式 ---
-main
+main "$@"


### PR DESCRIPTION
## Summary
- Ensure setup_vcpkg.sh forwards command line arguments to main

## Testing
- `shellcheck setup_vcpkg.sh`
- `bash -n setup_vcpkg.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895f13556bc832782f2485b66e459c0